### PR TITLE
Added 'Appearance Customization' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ Trigger Reamaze from anywhere (e.g. Button Press)
 }
 ```
 
+#### Appearance Customization
+
+If you decide to customize the appearance of the navigation bar within your app, a typical
+implementation can be:
+
+```obj-c
+[[UINavigationBar appearance] setTitleTextAttributes:@{
+                                                           NSFontAttributeName: [UIFont fontWithName:myFontName size:mySize],
+                                                           NSForegroundColorAttributeName:myColor
+                                                           }];
+[[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil] setTitleTextAttributes:@{
+                                                                                                       NSFontAttributeName: [UIFont fontWithName:myFont size:mySize],
+                                                                                                       NSForegroundColorAttributeName: myColor
+                                                                                                       }
+                                                                                        forState:UIControlStateNormal];
+[[UIBarButtonItem appearanceWhenContainedIn:[UINavigationBar class], nil] setTitleTextAttributes:@{
+                                                                                                       NSForegroundColorAttributeName: myColorWithHalfAlpha
+                                                                                                       }
+                                                                                        forState:UIControlStateDisabled];
+```
+
 #### Optional Delegation
 
 Create a class that conforms to the `ReamazeControllerDelegate` protocol.


### PR DESCRIPTION
I had to look into the code to understand that the Back button in the navigation bar was disabled when the webview couldn't go back. I thought it could be helpful for others to include a sample minimal code when deciding to change the appearance of the nav bar (the most useful part being the last instruction: setting the disabled state with 50% alpha).
